### PR TITLE
Fix : initialized Boolean indicating amica crash

### DIFF
--- a/bemobil_signal_decomposition.m
+++ b/bemobil_signal_decomposition.m
@@ -58,6 +58,8 @@ else
     out_filename = EEG.filename;
 end
 
+amica_crashed = false; 
+
 if amica
 	
 	if ~exist('AMICA_autoreject', 'var')


### PR DESCRIPTION
Found a bug in my recent PR - function will crash if variable amica_crash is not initialized before the amica loop