### PR TITLE
Follow-up changes 

### DIFF
--- a/import/bemobil_bids2set.m
+++ b/import/bemobil_bids2set.m
@@ -13,7 +13,13 @@ function bemobil_bids2set(config)
 %       config.session_names          = {'body', 'joy'};                    % required, enter task name as a string, or enter a cell array when there are multiple sessions in the data set  
 %       config.overwrite              = 'on';                               % optional, default value 'off' 
 %       config.filename_prefix        = 'sub-';                             % optional, default value 'sub-' 
-
+%       config.match_electrodes_channels = {'g1', 'G01'; 'g2', 'G02';...};  % optional, 2x NChan (number of channels in EEG data) array of strings, in case electrode names 
+%                                                                             in electrodes.tsv and channels.tsv do not match with
+%                                                                             each other. First column contains labels in electrodes.tsv
+%                                                                             and the second column contains lables in channels.tsv. 
+%                                                                             Resulting chanloc will take labels from eloc file. 
+%                                                                             Use empty string for a missing chanloc 
+%                                                                                   example : {'', 'N01'; 'n2', 'N02'; ...}
 %
 % Out
 %       none
@@ -43,6 +49,7 @@ config = checkfield(config, 'merged_filename', 'merged.set', 'merged.set');
 config = checkfield(config, 'other_data_types', {'motion'}, 'motion'); 
 config = checkfield(config, 'resample_freq', 250, '250 Hz'); 
 config = checkfield(config, 'overwrite', 'off', 'off'); 
+config = checkfield(config, 'match_electrodes_channels', [], 'none');
 
 % check session input
 if ~iscell(config.session_names)
@@ -92,7 +99,7 @@ end
 
 % Import data set saved in BIDS, using a modified version of eeglab plugin 
 %--------------------------------------------------------------------------
-pop_importbids_mobi(bidsDir,'datatypes',otherDataTypes,'outputdir', tempDir, 'participants', numericalIDs);
+pop_importbids_mobi(bidsDir,'datatypes',otherDataTypes,'outputdir', tempDir, 'participants', numericalIDs, 'matchchanlocs', config.match_electrodes_channels);
 
 % Restructure and rename the output of the import function
 %--------------------------------------------------------------------------

--- a/import/bemobil_xdf2bids.m
+++ b/import/bemobil_xdf2bids.m
@@ -386,6 +386,7 @@ end
 %% 
 % load and assign streams (parts taken from xdf2fieldtrip)
 %--------------------------------------------------------------------------
+disp('Loading .xdf streams ...')
 streams                  = load_xdf(cfg.dataset);
 
 % initialize an array of booleans indicating whether the streams are continuous

--- a/import/bemobil_xdf2bids.m
+++ b/import/bemobil_xdf2bids.m
@@ -12,7 +12,6 @@ function bemobil_xdf2bids(config, varargin)
 %       config.run                    = 1;                                  % optional
 %       config.task                   = 'rotation';                         % optional 
 %       config.acquisition_time       = [2021,9,30,18,14,0.00];             % optional ([YYYY,MM,DD,HH,MM,SS]) 
-%       config.overwrite              = 'on';                               % optional, default is off (when participant folder is found, data will NOT be overwritten)
 % 
 %       config.eeg.stream_name        = 'BrainVision';                      % required
 %       config.eeg.chanloc            = 'P:\...SPOT_rotation\0_raw-data\vp-1'\vp-1.elc'; % optional
@@ -318,24 +317,6 @@ end
 
 
 %%
-% check if the target folder is already there
-%--------------------------------------------------------------------------
-pDir = fullfile(config.bids_target_folder, ['sub-' num2str(config.subject)]);
-if exist(pDir, 'dir')
-    disp(['Subject folder ' pDir ' already exists.']);
-    if isfield(config, 'overwrite')
-        if strcmpi(config.overwrite, 'on')
-            warning('config.overwrite option is "on", Files will be overwritten')
-        else
-            warning('config.overwrite option is not "on", skipping import.')
-            return; 
-        end
-    else
-        warning('config.overwrite option is not "on", skipping import.')
-        return; 
-    end
-end
-
 % check if numerical IDs match subject info, if this was specified
 %--------------------------------------------------------------------------
 if exist('subjectInfo','var')

--- a/import/bemobil_xdf2bids.m
+++ b/import/bemobil_xdf2bids.m
@@ -508,7 +508,7 @@ if importEEG % This loop is always executed in current version
     %----------------------------------------------------------------------
     
     % construct fieldtrip data
-    eeg        = stream2ft(xdfeeg{1}, 'EEG');
+    eeg        = stream2ft(xdfeeg{1});
     
     % save eeg start time
     eegStartTime                = eeg.time{1}(1);

--- a/import/bemobil_xdf2bids.m
+++ b/import/bemobil_xdf2bids.m
@@ -470,6 +470,8 @@ if importEEG
     
     if isempty(xdfeeg)
         error('No eeg streams found - check whether stream_name match the names of streams in .xdf')
+    elseif numel(xdfeeg) > 1
+        error('Multiple eeg streams found - usage not supported')
     end
 end
 
@@ -504,8 +506,9 @@ if importEEG % This loop is always executed in current version
     %----------------------------------------------------------------------
     %                   Convert EEG Data to BIDS
     %----------------------------------------------------------------------
+    
     % construct fieldtrip data
-    eeg        = stream2ft(xdfeeg{1});
+    eeg        = stream2ft(xdfeeg{1}, 'EEG');
     
     % save eeg start time
     eegStartTime                = eeg.time{1}(1);
@@ -633,7 +636,7 @@ if importMotion
     % construct fieldtrip data
     ftmotion = {};
     for iM = 1:numel(xdfmotion)
-        ftmotion{iM} = stream2ft(xdfmotion{iM});
+        ftmotion{iM} = stream2ft(xdfmotion{iM}, 'motion');
     end
     
     % iterate over tracking systems
@@ -750,7 +753,7 @@ if importMotion
         
         % shift acq_time to store relative offset to eeg data
         acq_time = datenum(config.acquisition_time) + (motionTimeShift/(24*60*60));
-        motioncfg.acq_time = datestr(acq_time,'yyyy-mm-ddTHH:MM:SS.FFF'); % milisecond precision
+        motioncfg.scans.acq_time = datestr(acq_time,'yyyy-mm-ddTHH:MM:SS.FFF'); % milisecond precision
   
         % effective sampling rate 
         motioncfg.motion.TrackingSystems.(trackSysInData{tsi}).SamplingFrequencyEffective = effectiveSRate; 
@@ -812,7 +815,7 @@ if importPhys
         
         % shift acq_time to store relative offset to eeg data
         acq_time = datenum(config.acquisition_time) + (physioTimeShift/(24*60*60));
-        physiocfg.acq_time = datestr(acq_time,'yyyy-mm-ddTHH:MM:SS.FFF');
+        physiocfg.scans.acq_time = datestr(acq_time,'yyyy-mm-ddTHH:MM:SS.FFF');
         
         % start time
         physiocfg.physio.StartTime                        = physioStartTime - eegStartTime;

--- a/import/bemobil_xdf2bids.m
+++ b/import/bemobil_xdf2bids.m
@@ -636,7 +636,7 @@ if importMotion
     % construct fieldtrip data
     ftmotion = {};
     for iM = 1:numel(xdfmotion)
-        ftmotion{iM} = stream2ft(xdfmotion{iM}, 'motion');
+        ftmotion{iM} = stream2ft(xdfmotion{iM});
     end
     
     % iterate over tracking systems

--- a/pop/pop_importbids_mobi.m
+++ b/pop/pop_importbids_mobi.m
@@ -603,6 +603,7 @@ for iSubject = 2:size(bids.participants,1)
                 splitName       = regexp(otherFileRaw,'_','split');
                 datatype        = splitName{end}(1:end-4);
                
+                tracksys = []; 
                 % json name (for motion data, remove tracksys key-value pair)
                 for SNi = 1:numel(splitName)
                    if contains(splitName{SNi}, 'tracksys-')
@@ -612,6 +613,7 @@ for iSubject = 2:size(bids.participants,1)
                         break; 
                    end
                 end
+                
                 joinedName = join(splitName, '_'); 
                 otherFileJSON   = [joinedName{1}(1:end-3) 'json']; 
                 
@@ -628,6 +630,13 @@ for iSubject = 2:size(bids.participants,1)
                         importChan          = true;
                         channelFileMotion   = searchparent(subjectFolder{iFold}, '*_channels.tsv');
                         channelData         = loadfile(channelFileMotion(1).name, channelFileMotion); % this might have to change along with motion BEP
+                        
+                        % in case of motion data, guarantee that the number of channels for the particular tracking system matches the data 
+                        if ~isempty(tracksys)
+                            colNames = channelData(1,:);
+                            trackSysCol = find(strcmp(colNames, 'tracking_system')); 
+                            channelData = channelData([1; find(strcmp(channelData(:,trackSysCol), tracksys))],:); 
+                        end
                         
                         % coordinate system file (potentially shared with EEG)
                         importCoord 	= true;
@@ -778,10 +787,6 @@ for iSubject = 2:size(bids.participants,1)
                             else
                                 DATA.times  = (0:1000/infoData.SamplingFrequency:(size(DATA.data,2)/infoData.SamplingFrequency)*1000); % time is in ms
                             end
-
-%                             if strcmp(datatype,'motion') && infoData.MotionChannelCount ~= size(DATA.data,1)
-%                                 warning('Motion channel count mismatch between the data and motion.json')
-%                             end
                             
                             DATA.nbchan = size(DATA.data,1);
                             DATA.pnts   = size(DATA.data,2);


### PR DESCRIPTION
Follow-up PR after usability/BIDS compatibility update

- events are now copied to motion/phys data as well
- when labelds in BIDS elctrodes.tsv and channels.tsv mismatch, user can specify pairs
- overwrite "off" option for xdf2bids is non-functional and thus removed 