### PR TITLE
Import uses latency (timestamps) for motion data.

### DIFF
--- a/import/bemobil_bids2set.m
+++ b/import/bemobil_bids2set.m
@@ -374,7 +374,11 @@ for iSub = 1:numel(subDirList)
                 for MFi = 1:numel(modalityFiles)
                     % identify all tracking systems included in the session
                     modalityNamesSplit              = regexp(modalityFiles{MFi}, '_', 'split');
-                    trackingSystemsInSession{MFi}         = modalityNamesSplit{:,end-1};  
+                    if contains(modalityNamesSplit{:,end-1}, 'rec')
+                        trackingSystemsInSession{MFi}         = modalityNamesSplit{:,end-2};
+                    else
+                        trackingSystemsInSession{MFi}         = modalityNamesSplit{:,end-1};
+                    end
                 end
                 trackingSystemsInSession = unique(trackingSystemsInSession);
                 trackingSystemsInData   = [trackingSystemsInData trackingSystemsInSession];

--- a/import/bemobil_bids2set.m
+++ b/import/bemobil_bids2set.m
@@ -583,7 +583,7 @@ resamplecfg.method      = resampleMethod;
 resamplecfg.extrapval   = nan; 
 EEG.group = 1; EEG.condition = 1;
 ftData                  = eeglab2fieldtrip( EEG, 'raw', 'none' );
-ftData.time{1}          = ftData.time{1} + offset; 
+ftData.time{1}          = oldTimes/1000 + offset; 
 resampledData           = ft_resampledata(resamplecfg, ftData);
 EEG.data                = resampledData.trial{1};
 EEG.srate               = newSRate;

--- a/import/bemobil_bids2set.m
+++ b/import/bemobil_bids2set.m
@@ -467,7 +467,7 @@ for iSub = 1:numel(subDirList)
                     fillIndices = zeros(1,numel(config.session_names)); 
                     
                     for Si = 1:numel(config.session_names)
-                        if strcmp(bemobilModality, 'MOTION') && isMultiTrackSys
+                        if strcmpi(otherDataTypes{iType}, 'MOTION')
                             [outPath, outName] = sessionfilename(targetDir,['MOTION_' trackingSystemsInData{TSi}], config, Si, subjectNr);
                         else
                             [outPath, outName] = sessionfilename(targetDir, upper(otherDataTypes{iType}), config, Si, subjectNr);
@@ -511,7 +511,7 @@ for iSub = 1:numel(subDirList)
                     
                      ALLDATA = []; CURRENTSET = []; DATA = []; 
                     for Si = 1:numel(config.session_names)
-                        if strcmp(bemobilModality, 'MOTION') && isMultiTrackSys
+                        if strcmpi(otherDataTypes{iType}, 'MOTION')
                             [outPath, outName] = sessionfilename(targetDir,['MOTION_' trackingSystemsInData{TSi}], config, Si, subjectNr);
                         else
                             [outPath, outName] = sessionfilename(targetDir, upper(otherDataTypes{iType}), config, Si, subjectNr);
@@ -526,7 +526,7 @@ for iSub = 1:numel(subDirList)
                             [ALLDATA,DATA,CURRENTSET]  = pop_newset(ALLDATA, DATA, CURRENTSET, 'study',0);
                         end
                     end
-                    if strcmp(bemobilModality, 'MOTION') && isMultiTrackSys
+                    if strcmpi(otherDataTypes{iType}, 'MOTION')
                         [~, ~, ~]  = bemobil_merge(ALLDATA, DATA, CURRENTSET, 1:length(ALLDATA), [config.filename_prefix, num2str(subjectNr), '_MOTION_' trackingSystemsInData{TSi} '_' config.merged_filename], fullfile(targetDir, [config.filename_prefix, num2str(subjectNr)]));
                     else
                         [~, ~, ~]  = bemobil_merge(ALLDATA, DATA, CURRENTSET, 1:length(ALLDATA), [config.filename_prefix, num2str(subjectNr), '_' upper(otherDataTypes{iType}) '_' config.merged_filename], fullfile(targetDir, [config.filename_prefix, num2str(subjectNr)]));

--- a/import/bemobil_bids2set.m
+++ b/import/bemobil_bids2set.m
@@ -21,6 +21,7 @@ function bemobil_bids2set(config)
 %                                                                             Resulting chanloc will take labels from eloc file. 
 %                                                                             Use empty string for a missing chanloc 
 %                                                                                   example : {'', 'N01'; 'n2', 'N02'; ...}
+%       config.other_data_types        = {};                                % optional, default value {'motion'}   
 %
 % Out
 %       none
@@ -556,8 +557,14 @@ end
 function [outEEG] = resampleToTime(EEG, newSRate, tFirst, tLast, offset)
 % offset is in seconds 
 %--------------------------------------------------------------------------
+
 % check if any row is all zeros - use nearest interp if so
-hasNonZero = any(EEG.data,2);
+hasNonZero = zeros(size(EEG.data,1));
+
+for iRow = 1:size(EEG.data,1)
+   hasNonZero(iRow) = any(EEG.data(iRow,:));
+end
+
 if any(hasNonZero == 0)
     resampleMethod = 'nearest'; 
 else

--- a/import/bemobil_bids_motionconvert.m
+++ b/import/bemobil_bids_motionconvert.m
@@ -1,17 +1,43 @@
 
-function motionOut = bemobil_bids_motionconvert(motionIn, objects, pi, si, ri)
+function motionOut = bemobil_bids_motionconvert(motionIn, objects, trackSysConfig)
 
-% your quaternion [w,x,y,z] components, in this order
-quaternionComponents    = {'w','x','y','z'};
+% quaternion [w,x,y,z] components, in this order
+if isfield(trackSysConfig, 'quaternions')
+    quaternionComponents    = trackSysConfig.quaternions;    
+else
+    quaternionComponents    = {'w','x','y','z'};
+end
 
-% your euler components - the rotation order of the output of quat2eul will be reversed 
-eulerComponents         = {'x','y','z'}; 
+% euler angle components - the rotation order of the output of quat2eul will be reversed 
+if isfield(trackSysConfig, 'euler_components')
+    eulerComponents         = trackSysConfig.euler_components;    
+else
+    eulerComponents         = {'x','y','z'}; 
+end
 
-% yourcartesian coordinates 
-cartCoordinates         = {'x','y','z'};
+% cartesian coordinates 
+if isfield(trackSysConfig, 'euler_components')
+    cartCoordinates         = trackSysConfig.cartCoordinates;    
+else
+    cartCoordinates         = {'x','y','z'};
+end
+
 
 % missing value (how tracking loss is represented in the stream)
-missingval = 0; 
+if isfield(trackSysConfig, 'missing_values')
+    switch trackSysConfig.missing_values
+        case '0'
+            missingval = 0;
+        case 'NaN'
+            missingval = NaN;
+        otherwise
+            warning(['Unrecognized value for field "missing_values" in tracking system ' trackSysConfig.name ': it should be "0" or "NaN" formatted as string.'])
+            warning('Taking default value NaN for missing samples.')
+            missingval = NaN;
+    end
+else
+    missingval = NaN;
+end
 
 newCell = {}; 
 % check if object input is a nested cell

--- a/import/bemobil_bids_motionconvert.m
+++ b/import/bemobil_bids_motionconvert.m
@@ -234,15 +234,12 @@ for iM = 1:numel(motionIn)
            cartIndices  = [];  
         end
         
-        % construct a latency channel
-        latency  = motionStream.time{1};
-        
         % all other channels 
         otherChans          = setdiff(objectChans, union(cartIndices, quaternionIndices));
         otherData           = dataPre(otherChans,:);
         
         % concatenate the converted data
-        objectData         = [orientationInEuler; position; otherData; latency];
+        objectData         = [orientationInEuler; position; otherData];
         dataPost           = [dataPost; objectData];
         
         % enter channel information
@@ -270,21 +267,25 @@ for iM = 1:numel(motionIn)
                 motionStream.hdr.chanunit{end + 1}          = 'n/a';
             end
         end
+            
+    end
+    
+    % only include streams that have data from at least one object 
+    if oi > 0
         
+        % construct a latency channel
+        latency  = motionStream.time{1};
+        dataPost = [dataPost; latency];
         motionStream.label{end + 1}                 = [objects{ni} '_latency'];
         motionStream.hdr.label{end + 1}             = [objects{ni} '_latency'];
         motionStream.hdr.chantype{end + 1}          = 'LATENCY';
         motionStream.hdr.chanunit{end + 1}          = 'seconds';
-        
-    end
-    
-    % only include streams that have data from at least one object 
-    if oi > 0 
         motionStream.trial{1}     = dataPost;
         motionStream.hdr.nChans   = numel(motionStream.hdr.chantype);
         
         % add time stamps channel to the stream before concatenating
         motionStreamAll{iM}       = motionStream;
+        
     end
     
 end

--- a/import/bemobil_bids_motionconvert.m
+++ b/import/bemobil_bids_motionconvert.m
@@ -291,20 +291,20 @@ end
 
 %--------------------------------------------------------------------------
 % find the one with the highest sampling rate 
-% & check if data can be reasonably concatenated
+% & check if there are multiple streams in a single tracking system 
 motionsrates    = []; 
-nSamples        = []; 
 for iM = 1:numel(motionStreamAll)
     motionsrates(iM) = motionStreamAll{iM}.hdr.Fs; 
-    nSamples(iM)     = motionStreamAll{iM}.hdr.nSamples; 
 end
 
-if all(nSamples(:) == nSamples(1))
+if numel(motionStreamAll) == 1
+    % if there is one motion stream, check the config field to decide
+    % whether to resample or keep timestamps 
     doResample      = ~strcmp(trackSysConfig.keep_timestamps, 'on'); 
 else
     doResample      = true;
     if strcmp(trackSysConfig.keep_timestamps, 'on') 
-        warning('Config field keep_timestamps was specified as "on", but number of samples among streams in tracksys do not match - resampling...')
+        warning('Config field keep_timestamps was specified as "on", but there are multiple streams in a single tracking system - resampling...')
     end
 end
 

--- a/import/bemobil_bids_physioconvert.m
+++ b/import/bemobil_bids_physioconvert.m
@@ -1,5 +1,5 @@
 
-function physioOut = bemobil_bids_physioconvert(physioIn, objects, pi, si, ri)
+function physioOut = bemobil_bids_physioconvert(physioIn, objects, pi, si, ri, interpPhys)
 % Process generic physiological data 
 % (resampling to the highest sampling rate among all streams of the type)
 
@@ -32,9 +32,19 @@ for iP = 1:numel(physioIn)
     
     % do not include streams that contain 0 objects
     if oi > 0 
+        
+        % construct a latency channel
+        latency  = physioStream.time{1};
+        dataPost = [dataPost; latency];
+        physioStream.label{end + 1}                 = [objects{ni} '_latency'];
+        physioStream.hdr.label{end + 1}             = [objects{ni} '_latency'];
+        physioStream.hdr.chantype{end + 1}          = 'LATENCY';
+        physioStream.hdr.chanunit{end + 1}          = 'seconds';
+        
         physioStream.trial{1}     = dataPost;
         physioStream.hdr.nChans   = numel(physioStream.hdr.chantype);
         physioStreamAll{iP}       = physioStream;
+        
     end
     
 end
@@ -45,6 +55,18 @@ physiosrates = [];
 
 for iP = 1:numel(physioStreamAll)
     physiosrates(iP) = physioStreamAll{iP}.hdr.Fs; 
+end
+
+
+if numel(physioStreamAll) == 1
+    % if there is one physio stream, check the config field to decide
+    % whether to resample or keep timestamps 
+    doResample      = interpPhys; 
+else
+    doResample      = true;
+    if interpPhys 
+        warning('Config field phys.skip_interp was specified as true, but there are multiple streams to be concatenated - resampling via interpolation')
+    end
 end
 
 [~,maxind] = max(physiosrates);
@@ -78,14 +100,16 @@ if numel(physioStreamAll)>1
         keephdr.chantype    = [keephdr.chantype;    physioStreamAll{i}.hdr.chantype];
         keephdr.chanunit    = [keephdr.chanunit;    physioStreamAll{i}.hdr.chanunit];
         
-        % resample
-        %------------------------------------------------------------------ 
-        ft_notice('resampling %s', physioStreamAll{i}.hdr.orig.name);
-        cfg                 = [];
-        cfg.time            = regularTime;
-        cfg.detrend         = 'no'; 
-        physioStreamAll{i}  = ft_struct2double(physioStreamAll{i});
-        physioStreamAll{i}  = ft_resampledata(cfg, physioStreamAll{i});
+        if doresample
+            % resample
+            %------------------------------------------------------------------
+            ft_notice('resampling %s', physioStreamAll{i}.hdr.orig.name);
+            cfg                 = [];
+            cfg.time            = regularTime;
+            cfg.detrend         = 'no';
+            physioStreamAll{i}  = ft_struct2double(physioStreamAll{i});
+            physioStreamAll{i}  = ft_resampledata(cfg, physioStreamAll{i});
+        end
     end
     
     % append all data structures

--- a/import/bemobil_xdf2bids.m
+++ b/import/bemobil_xdf2bids.m
@@ -487,9 +487,11 @@ if importEEG
 end
 
 if importMotion
+    
     for Si = 1:numel(config.motion.streams) 
-        motionStreamNames{Si}   = config.motion.streams{Si}.stream_name;
+        motionStreamNames{Si}   = config.motion.streams{Si}.name;
     end
+    
     xdfmotion   = streams(contains(lower(names),lower(motionStreamNames)) & iscontinuous);
     
     if isempty(xdfmotion)
@@ -617,7 +619,7 @@ if importEEG % This loop is always executed in current version
     
     % acquisition time processing 
     eegcfg.acq_time = datestr(datenum(config.acquisition_time),'yyyy-mm-ddTHH:MM:SS.FFF'); % microseconds are rounded
-    
+
     % write eeg files in bids format
     data2bids(eegcfg, eeg);
     
@@ -642,7 +644,6 @@ if importMotion
     motioncfg.coordsystem.MotionRotationRule          = motionInfo.coordsystem.MotionRotationRule;
     motioncfg.coordsystem.MotionRotationOrder         = motionInfo.coordsystem.MotionRotationOrder;
     motioncfg.TrackingSystemCount                     = numel(trackSysInData);
-
 
     % construct fieldtrip data
     ftmotion = {};
@@ -707,8 +708,11 @@ if importMotion
            end
         end
         
+        % select tracking system configuration 
+        trackSysConfig = config.motion.tracksys{strcmp(tracking_systems, trackSysInData{tsi})}; 
+        
         % quat2eul conversion, unwrapping of angles, resampling, wrapping back to [pi, -pi], and concatenating
-        motion = bemobil_bids_motionconvert(ftmotion(streamInds), trackedPointNames, config.subject, si, ri, interpMotion);
+        motion = bemobil_bids_motionconvert(ftmotion(streamInds), trackedPointNames, trackSysConfig);
         
         % channel metadata 
         %------------------------------------------------------------------

--- a/import/bemobil_xdf2bids.m
+++ b/import/bemobil_xdf2bids.m
@@ -15,18 +15,18 @@ function bemobil_xdf2bids(config, varargin)
 % 
 %       config.eeg.stream_name        = 'BrainVision';                      % required
 %       config.eeg.chanloc            = 'P:\...SPOT_rotation\0_raw-data\vp-1'\vp-1.elc'; % optional
-%       config.eeg.elec_struct        = elecStruct                          % optional, alternative to config.eeg.chanloc. Output struct of ft_read_sens 
-%       config.eeg.chanloc_newname    = {'chan1', 'chan2'}                  % optional, cell array of size nchan X 1,  containing new chanloc labels in case you want to rename them 
+%       config.eeg.elec_struct        = elecStruct;                         % optional, alternative to config.eeg.chanloc. Output struct of ft_read_sens 
+%       config.eeg.chanloc_newname    = {'chan1', 'chan2'};                 % optional, cell array of size nchan X 1,  containing new chanloc labels in case you want to rename them 
 %         
-%       config.motion.streams{1}.stream_name        = 'stream1';            % keyword in stream name  
+%       config.motion.streams{1}.stream_name        = 'stream1';            % required, keyword in stream name  
 %                                                                                   % searched for in field "xdfdata{streamIndex}.info.name"
-%       config.motion.streams{1}.tracking_system    = 'HTCVive';            % user-defined name of the tracking system
+%       config.motion.streams{1}.tracking_system    = 'HTCVive';            % required, user-defined name of the tracking system
 %                                                                                   % in case motion metadata are provided, match with fieldname in "motionInfo.motion.TrackingSystems.(fieldname)"
 %                                                                                   % e.g., motionInfo.motion.TrackingSystems.HTCVive.Manufacturer = 'HTC'; 
-%       config.motion.streams{1}.tracked_points     = 'rigid1';             % keyword in channel names, indicating which object (tracked point) is included in the stream 
+%       config.motion.streams{1}.tracked_points     = 'rigid1';             % required, keyword in channel names, indicating which object (tracked point) is included in the stream 
 %                                                                                   % searched for in field "xdfdata{streamIndex}.info.desc.channels.channel{channelIndex}.label"
 %                                                                                   % required to be unique in a single tracking system
-%       config.motion.streams{1}.tracked_points_anat = 'leftFoot';          % user-defined anatomical name of the point being tracked 
+%       config.motion.streams{1}.tracked_points_anat = 'leftFoot';          % optional, user-defined anatomical name of the point being tracked 
 %       config.motion.streams{2}.stream_name        = 'stream2'; 
 %       config.motion.streams{2}.tracking_system    = 'HTCVive'; 
 %       config.motion.streams{2}.tracked_points     = 'rigid2';
@@ -36,7 +36,7 @@ function bemobil_xdf2bids(config, varargin)
 %       config.motion.streams{3}.tracked_points     = {'leftFoot', 'rightFoot'}; % keywords in channel names, when multiple tracked points are included in a single stream 
 %       config.motion.POS.unit                      = 'vm';                 % optional, in case you want to use custom unit
 %
-%       config.phys.streams{1}.stream_name        = {'force1'};             % optional
+%       config.phys.streams{1}.stream_name          = {'force1'};           % optional
 %
 %--------------------------------------------------------------------------
 % Optional Inputs :

--- a/import/bemobil_xdf2bids.m
+++ b/import/bemobil_xdf2bids.m
@@ -35,10 +35,10 @@ function bemobil_xdf2bids(config, varargin)
 %                                                                           % in case motion metadata are provided, match with fieldname in "motionInfo.motion.TrackingSystems.(fieldname)"
 %                                                                           % e.g., motionInfo.motion.TrackingSystems.HTCVive.Manufacturer = 'HTC'; 
 %       config.motion.tracksys{1}.quaternions             = {'w','x','y','z'}; % optional, your quaternion [w,x,y,z] components, in this order. if specified, script will find and convert quaternion elements to euler angles
-%       config.motion.tracksys{1}.eulercomponents         = {'x','y','z'};  % optional, your euler components - the rotation order of the output of quat2eul will be reversed 
-%       config.motion.tracksys{1}.cartesiancoordinates    = {'x','y','z'};  % optional, your cartesian coordinates for position data
-%       config.motion.tracksys{1}.keeptimestamps          = 'on';           % optional, 'on' by default, 'off' will lead to interpolation for making intersample intervals regular 
-%       config.motion.tracksys{1}.missingValues           = 'NaN';          % optional, how missing samples are represented in the stream. takes one of the values from 'NaN', '0';   
+%       config.motion.tracksys{1}.euler_components        = {'x','y','z'};  % optional, your euler components - the rotation order of the output of quat2eul will be reversed 
+%       config.motion.tracksys{1}.cartesian_coordinates   = {'x','y','z'};  % optional, your cartesian coordinates for position data
+%       config.motion.tracksys{1}.keep_timestamps         = 'on';           % optional, 'on' by default, 'off' will lead to interpolation for making intersample intervals regular 
+%       config.motion.tracksys{1}.missing_values          = 'NaN';          % optional, how missing samples are represented in the stream. takes one of the values from 'NaN', '0';   
 %       config.motion.tracksys{1}.POS.unit                = 'vm';           % optional, in case you want to use custom unit
 %       
 %       config.motion.tracksys{2}.name                    = 'HTCVive';     

--- a/import/bemobil_xdf2bids.m
+++ b/import/bemobil_xdf2bids.m
@@ -121,17 +121,6 @@ if importMotion
         config.motion.streams{Si} = checkfield(config.motion.streams{Si}, 'tracked_points', 'required', '');
     end
     
-    if isfield(config.motion, 'custom_function')
-        if isempty(config.motion.custom_function)
-            % functions that resolve dataset-specific problems
-            motionCustom            = 'bemobil_bids_motionconvert';
-        else
-            motionCustom            = config.motion.custom_function;
-        end
-
-    else
-        motionCustom = 'bemobil_bids_motionconvert'; 
-    end
     
     % default channel types and units
     motion_type.POS.unit        = 'm'; 
@@ -679,10 +668,9 @@ if importMotion
            end
         end
         
-        % if needed, execute a custom function for any alteration to the data to address dataset specific issues
-        % (quat2eul conversion, unwrapping of angles, resampling, wrapping back to [pi, -pi], and concatenating for instance)
-        motion = feval(motionCustom, ftmotion(streamInds), trackedPointNames, config.subject, si, ri);
-      
+        % quat2eul conversion, unwrapping of angles, resampling, wrapping back to [pi, -pi], and concatenating
+        motion = bemobil_bids_motionconvert(ftmotion(streamInds), trackedPointNames, config.subject, si, ri, interpMotion);
+        
         % channel metadata 
         %------------------------------------------------------------------
         rb_streams = motionStreamNames;

--- a/import/bemobil_xdf2bids.m
+++ b/import/bemobil_xdf2bids.m
@@ -148,6 +148,7 @@ if importMotion
     % check tracking system fields
     for Ti = 1:numel(config.motion.tracksys)
         config.motion.tracksys{Ti} = checkfield(config.motion.tracksys{Ti}, 'name', 'required', '');
+        config.motion.tracksys{Ti} = checkfield(config.motion.tracksys{Ti}, 'keep_timestamps', 'on', 'on');
         tracksysNames{end+1} = config.motion.tracksys{Ti}.name;  
     end
     
@@ -170,7 +171,7 @@ if importMotion
     motion_type.ANGACC.unit     = 'r/s^2';
     motion_type.MAGN.unit       = 'fm';
     motion_type.JNTANG.unit     = 'r';
-    motion_type.TIMESTAMPS.unit = 'timestamps'; 
+    motion_type.LATENCY.unit    = 'seconds'; 
 
 end
 
@@ -725,9 +726,9 @@ if importMotion
             motionChanType          = motion.hdr.chantype{ci};
             
             if isfield(config.motion, motionChanType)
-                motion.hdr.chanunit{ci} = config.motion.(motionChanType).unit; 
+                motion.hdr.chanunit{ci} = config.motion.(motionChanType).unit;
                 disp(['Using custom unit ' config.motion.(motionChanType).unit ' for type ' motionChanType])
-            else
+            elseif isfield(motion_type, motionChanType)
                 motion.hdr.chanunit{ci} = motion_type.(motionChanType).unit;
             end
             

--- a/import/bemobil_xdf2bids.m
+++ b/import/bemobil_xdf2bids.m
@@ -399,12 +399,13 @@ for i=1:numel(streams)
     
     names{i}           = streams{i}.info.name;
     
-    % if the nominal srate is non-zero, the stream is considered continuous
+    % if the nominal srate is non-zero, the stream may be considered continuous
     if ~strcmpi(streams{i}.info.nominal_srate, '0')
         
         num_samples  = numel(streams{i}.time_stamps);
+        nominalSRate = str2double(streams{i}.info.nominal_srate); 
         
-        if num_samples > 20 % assume at least 20 samples in a continuous data stream
+        if num_samples > 20 && nominalSRate > 0 % assume at least 20 samples in a continuous data stream
 
             iscontinuous(i) =  true;
             t_begin      = streams{i}.time_stamps(1);

--- a/pop/pop_importbids_mobi.m
+++ b/pop/pop_importbids_mobi.m
@@ -920,6 +920,9 @@ stats.eventConsistency   = 0;
 stats.channelConsistency = 0;
 stats.EventDescription    = 0;
 if ~isempty(bids.README), stats.README = 1; end
+if isempty(bids.participants)
+    error('No BIDS files found for specified participants')
+end
 if ismember('age'   , bids.participants(1,:)) && ismember('sex', bids.participants(1,:))
     stats.ParticipantsAgeAndSex = 1; 
 end


### PR DESCRIPTION
- default option is now to use time stamps in .xdf streams and save them as latency channel in BIDS data
- for motion data, instead of custom function, config fields can be used to specify information necessary for parsing channel labels in .xdf files and thus to recognize position or orientation data
- for BIDS files, data samples can now retain original values 
  (as fluctuating sample intervals over time can be captured by latency information)