### PR TITLE
BIDS motion .json tracksys style change & nominal srate storage

### DIFF
--- a/import/bemobil_xdf2bids.m
+++ b/import/bemobil_xdf2bids.m
@@ -285,6 +285,9 @@ if importMotion
         defaultTrackingSystems(Ti).Manufacturer                     = 'DefaultManufacturer';
         defaultTrackingSystems(Ti).ManufacturersModelName           = 'DefaultModel';
         defaultTrackingSystems(Ti).SamplingFrequency                = 'n/a'; %  If no nominal Fs exists, n/a entry returns 'n/a'. If it exists, n/a entry returns nominal Fs from motion stream.
+        defaultTrackingSystems(Ti).DeviceSerialNumber               = 'n/a';
+        defaultTrackingSystems(Ti).SoftwareVersions                 = 'n/a';
+        defaultTrackingSystems(Ti).ExternalSoftwareVersions         = 'n/a';
     end
     
     if ~exist('motionInfo', 'var')

--- a/import/bemobil_xdf2bids.m
+++ b/import/bemobil_xdf2bids.m
@@ -281,9 +281,10 @@ if importMotion
     tracking_systems                = trackSysInData;
     
     for Ti = 1:numel(tracking_systems)
-        defaultTrackingSystems.(tracking_systems{Ti}).Manufacturer                     = 'DefaultManufacturer';
-        defaultTrackingSystems.(tracking_systems{Ti}).ManufacturersModelName           = 'DefaultModel';
-        defaultTrackingSystems.(tracking_systems{Ti}).SamplingFrequencyNominal         = 'n/a'; %  If no nominal Fs exists, n/a entry returns 'n/a'. If it exists, n/a entry returns nominal Fs from motion stream.
+        defaultTrackingSystems(Ti).TrackingSystemName               = tracking_systems{Ti};
+        defaultTrackingSystems(Ti).Manufacturer                     = 'DefaultManufacturer';
+        defaultTrackingSystems(Ti).ManufacturersModelName           = 'DefaultModel';
+        defaultTrackingSystems(Ti).SamplingFrequency                = 'n/a'; %  If no nominal Fs exists, n/a entry returns 'n/a'. If it exists, n/a entry returns nominal Fs from motion stream.
     end
     
     if ~exist('motionInfo', 'var')
@@ -307,23 +308,24 @@ if importMotion
             if isfield(motionInfo.motion, 'TrackingSystems')
                 
                 % take all tracking systems defined in the metadata input
-                trackSysInMeta = fieldnames(motionInfo.motion.TrackingSystems);
+                trackSysInMeta = {motionInfo.motion.TrackingSystems(:).TrackingSystemName};
                 
                 % identify tracking systems in the data but not in metadata
                 trackSysNoMeta  = setdiff(trackSysInData, trackSysInMeta);
                 
                 % construct metadata for ones that are missing them
                 for Ti = 1:numel(trackSysNoMeta)
-                    motionInfo.motion.TrackingSystems.(trackSysNoMeta{Ti}).Manufacturer                     = 'DefaultManufacturer';
-                    motionInfo.motion.TrackingSystems.(trackSysNoMeta{Ti}).ManufacturerModelName            = 'DefaultModel';
-                    motionInfo.motion.TrackingSystems.(trackSysNoMeta{Ti}).SamplingFrequencyNominal         = 'n/a';
+                    defaultTrackingSystems(Ti).TrackingSystemName               = tracking_systems{Ti};
+                    defaultTrackingSystems(Ti).Manufacturer                     = 'DefaultManufacturer';
+                    defaultTrackingSystems(Ti).ManufacturersModelName           = 'DefaultModel';
+                    defaultTrackingSystems(Ti).SamplingFrequency                = 'n/a'; %  If no nominal Fs exists, n/a entry returns 'n/a'. If it exists, n/a entry returns nominal Fs from motion stream.
                 end
                 
                 % identify tracking systems in metadata but not in the data
-                trackSysNoData = setdiff(trackSysInMeta, trackSysInData);
+                [trackSysNoData, indrm] = setdiff(trackSysInMeta, trackSysInData);
                 
                 % remove unused tracking systems from metadata struct
-                motionInfo.motion.TrackingSystems = rmfield(motionInfo.motion.TrackingSystems, trackSysNoData);
+                motionInfo.motion.TrackingSystems(indrm) = [];
             else
                 warning('No information on tracking system given - filling with default info')
                 

--- a/import/bemobil_xdf2bids.m
+++ b/import/bemobil_xdf2bids.m
@@ -728,7 +728,7 @@ if importMotion
         streamsConfig = config.motion.streams;
          
         % quat2eul conversion, unwrapping of angles, resampling, wrapping back to [pi, -pi], and concatenating
-        motion = bemobil_bids_motionconvert(ftmotion(streamInds), trackedPointNames, trackSysConfig, streamsConfig);
+        motion = bemobil_bids_motionconvert(ftmotion(streamInds), trackedPointNames, trackSysConfig, streamsConfig(streamInds));
         
         % channel metadata 
         %------------------------------------------------------------------

--- a/import/bemobil_xdf2bids.m
+++ b/import/bemobil_xdf2bids.m
@@ -664,6 +664,8 @@ if importMotion
     motioncfg.channels.tracked_point        = {};
     motioncfg.channels.component            = {};
     motioncfg.channels.placement            = {};
+    motioncfg.channels.type                 = {};
+    
     MotionChannelCount = 0;
         
     % copy motion metadata fields
@@ -744,6 +746,7 @@ if importMotion
             splitlabel                                      = regexp(motion.hdr.label{ci}, '_', 'split');
             motioncfg.channels.name{end+1}                  = motion.hdr.label{ci};
             motioncfg.channels.tracking_system{end+1}       = trackSysInData{tsi};
+            motioncfg.channels.type{end+1}                  = motion.hdr.chantype{ci};
             
             % assign object names and anatomical positions
             for iN = 1:numel(rb_names)
@@ -776,17 +779,16 @@ if importMotion
         acq_time = datenum(config.acquisition_time) + (motionTimeShift/(24*60*60));
         motioncfg.scans.acq_time = datestr(acq_time,'yyyy-mm-ddTHH:MM:SS.FFF'); % milisecond precision
   
-        tempTSNames         = {motioncfg.motion.TrackingSystems(:).TrackingSystemName};
-        tempTSi             = find(strcmp(tempTSNames,trackSysInData{tsi}));  
-        
+        % tracking system information will be appended with iterations
+        %------------------------------------------------------------------
         % effective sampling rate 
-        motioncfg.motion.TrackingSystems(tempTSi).SamplingFrequencyEffective = effectiveSRate; 
+        motioncfg.motion.TrackingSystems(tsi).SamplingFrequencyEffective = effectiveSRate; 
         
         % RecordingDuration
-        motioncfg.motion.TrackingSystems(tempTSi).RecordingDuration = (motion.hdr.nSamples*motion.hdr.nTrials)/effectiveSRate;
+        motioncfg.motion.TrackingSystems(tsi).RecordingDuration = (motion.hdr.nSamples*motion.hdr.nTrials)/effectiveSRate;
 
         % add the number of tracking points to tracked point count
-        motioncfg.motion.TrackingSystems(tempTSi).TrackedPointsCount = sum(numel(trackedPointNames)); % add entries which contain rb_name for corresponding tracking system
+        motioncfg.motion.TrackingSystems(tsi).TrackedPointsCount = sum(numel(trackedPointNames)); % add entries which contain rb_name for corresponding tracking system
         
         % add the number of channels to MotionChannelCount
         motioncfg.motion.MotionChannelCount = MotionChannelCount + motion.hdr.nChans;

--- a/pop/pop_importbids_mobi.m
+++ b/pop/pop_importbids_mobi.m
@@ -590,7 +590,7 @@ for iSubject = 2:size(bids.participants,1)
                     % copy information inside dataset
                     EEG.subject = bids.participants{iSubject,1};
                     EEG.session = iFold;
-                    
+                    EEG.etc.nominal_srate = infoData.SamplingFrequency;
                     if strcmpi(opt.metadata, 'off')
                         if exist(subjectFolderOut{iFold},'dir') ~= 7
                             mkdir(subjectFolderOut{iFold});
@@ -756,8 +756,9 @@ for iSubject = 2:size(bids.participants,1)
                             end
                             
                             if strcmp(datatype,'motion') && isfield(infoData, 'TrackingSystems')
-                                
-                                DATA.srate  = infoData.TrackingSystems.(tracksys).SamplingFrequencyEffective; 
+                                tsi = find(strcmp({infoData.TrackingSystems(:).TrackingSystemName}, tracksys));
+                                DATA.srate                  = infoData.TrackingSystems(tsi).SamplingFrequencyEffective; 
+                                DATA.etc.nominal_srate      = infoData.TrackingSystems(tsi).SamplingFrequency;
                             else
                                 try
                                     DATA.srate  = infoData.SamplingFrequencyEffective; % Actual sampling rate used in motion data. Note that the unit of the time must be in second.
@@ -841,7 +842,8 @@ for iSubject = 2:size(bids.participants,1)
                                 DATA.data(latencyRowInData,:)   = [];
                             else
                                 if isfield(infoData, 'TrackingSystems')
-                                    DATA.times  = (0:1000/infoData.TrackingSystems.(tracksys).SamplingFrequencyEffective:infoData.TrackingSystems.(tracksys).RecordingDuration*1000); % time is in ms
+                                    % tsi should have been defined ábove when srate was being read in
+                                    DATA.times  = (0:1000/infoData.TrackingSystems(tsi).SamplingFrequencyEffective:infoData.TrackingSystems(tsi).RecordingDuration*1000); % time is in ms
                                 elseif isfield(infoData, 'RecordingDuration')
                                     DATA.times  = (0:1000/infoData.SamplingFrequency:infoData.RecordingDuration*1000); % time is in ms
                                 else


### PR DESCRIPTION
- In motion BIDS files, tracking system information in .json is saved as a list of objects, instead of taking names of each tracking system as a property (for better compatibility with BIDS-validator).
- EEG srate takes nominal sampling rate whenever specified. Both motion and EEG nominal sampling rate information is saved in ".etc.nominal_srate" in respective set files
