### PR TITLE
Make config concise by removing raw_EEGLAB_data_folder field from bids2set config

### DIFF
--- a/import/bemobil_bids2set.m
+++ b/import/bemobil_bids2set.m
@@ -354,6 +354,11 @@ for iSub = 1:numel(subDirList)
                 % to prevent ft alt function from meddling with processing
                 rmpath(genpath(fullfile(ftPath, [filesep 'external' filesep 'signal'])))
                 
+                % remove events with NaN latency before resampling
+                eventLatencies      = [EEG.event(:).latency];
+                nanInds             = find(isnan(eventLatencies));
+                EEG.event(nanInds)  = []; 
+                
                 EEG                 = pop_resample( EEG, newSRate); % use filter-based resampling
                 %                 [EEG]       = resampleToTime(EEG, newSRate, EEG.times(1), EEG.times(end), 0); % resample
                 eegTimes{Ri}        = EEG.times;

--- a/import/bemobil_bids2set.m
+++ b/import/bemobil_bids2set.m
@@ -48,7 +48,6 @@ config = checkfield(config, 'subject', 'required', '');
 config = checkfield(config, 'session_names', 'required', '');
 
 % default values
-config = checkfield(config, 'raw_EEGLAB_data_folder', ['2_raw-EEGLAB' filesep], ['2_raw-EEGLAB' filesep]);
 config = checkfield(config, 'filename_prefix', 'sub-', 'sub-');
 config = checkfield(config, 'merged_filename', 'merged', 'merged');
 config = checkfield(config, 'other_data_types', {}, '{}');
@@ -70,7 +69,7 @@ otherDataTypes  = config.other_data_types;
 bidsDir         = fullfile(config.bids_target_folder);
 
 % all runs and sessions are merged by default
-targetDir       = fullfile(config.set_folder, config.raw_EEGLAB_data_folder);
+targetDir       = fullfile(config.set_folder);
 tempDir         = fullfile(targetDir, 'temp_bids');
 
 if isfolder(tempDir)


### PR DESCRIPTION
Originally there are two fields for configuring the output folder from BIDS2SET function, one which is set_folder, the full path to the data directory, and the other one which is saved in that data directory, raw_EEGLAB_data_folder field, which is just the name of the field. 

For better usability I propose letting users directly provide the full path. 

For example, instead of 

     config.set_folder = '....\ProjectWatermaze\WM_DATA'; 
     config.raw_EEGAB_data_folder = '2_raw-EEGLAB'; 

and then combining the two within bemobil_bids2set function, 
users can now directly specify the full path to the output folder

    config.set_folder = '....\ProjectWatermaze\WM_DATA\2_raw-EEGLAB';
    
Which is in my opinion easier to understand
Once we decide to incorporate this change we can then proceed to update the example.
But in the pipeline config field ".raw_EEGAB_data_folder" can probably stay because it will be used by the preprocessing script

