### PR TITLE
Compatibility update including a critical revision for latency reading

### DIFF
--- a/import/bemobil_xdf2bids.m
+++ b/import/bemobil_xdf2bids.m
@@ -179,6 +179,10 @@ if importMotion
     
 end
 
+% BIDS-motion Keywords list (according to BEP 029, Jan 2023)
+componentKeywords       = {'x' ,'y', 'z', 'quat_x', 'quat_y', 'quat_z', 'quat_w', 'n/a'};
+channelTypeKeywords     = {'ACCEL', 'ANGACC', 'GYRO', 'JNTANG', 'LATENCY', 'MAGN', 'MISC', 'ORNT', 'POS', 'TIME', 'VEL'};
+
 % physio-related fields
 %--------------------------------------------------------------------------
 if importPhys
@@ -957,6 +961,8 @@ if importMotion
                 disp(['Using custom unit ' config.motion.(motionChanType).unit ' for type ' motionChanType])
             elseif isfield(motion_type, motionChanType)
                 motion.hdr.chanunit{ci} = motion_type.(motionChanType).unit;
+            else
+                motion.hdr.chanunit{ci} = 'n/a';
             end
             
             splitlabel                                      = regexp(motion.hdr.label{ci}, '_', 'split');
@@ -981,6 +987,14 @@ if importMotion
             
             motioncfg.channels.component{end+1}    = splitlabel{end};
             
+            % make sure that the type and component keywords conform to BIDS 
+            if ~any(strcmp(motioncfg.channels.type{end},channelTypeKeywords))
+                motioncfg.channels.type{end}         = 'MISC';
+            end
+            
+            if ~any(strcmp(motioncfg.channels.component{end},componentKeywords))
+                motioncfg.channels.component{end}    = 'n/a'; 
+            end
         end
         
         % tracking system-specific information

--- a/import/bemobil_xdf2bids.m
+++ b/import/bemobil_xdf2bids.m
@@ -934,6 +934,10 @@ if importMotion
             end
         end
         
+        if isempty(streamInds)
+            continue; 
+        end
+        
         % select stream configuration
         streamsConfig       = config.motion.streams(streamConfigInds);
         
@@ -973,7 +977,7 @@ if importMotion
             
             % assign object names and anatomical positions
             for iN = 1:numel(rb_names)
-                if contains(lower(motion.hdr.label{ci}),lower(rb_names{iN}))
+                if contains(lower(motion.hdr.label{ci}),lower(rb_names{iN})) && ~contains(lower(motion.hdr.label{ci}), 'latency')
                     motioncfg.channels.tracked_point{end+1}        = rb_names{iN};
                     motioncfg.channels.placement{end+1}            = rb_anat{iN};
                 end

--- a/import/bemobil_xdf2bids.m
+++ b/import/bemobil_xdf2bids.m
@@ -75,7 +75,10 @@ function bemobil_xdf2bids(config, varargin)
 %--------------------------------------------------------------------------
 %       config.phys.streams{1}.stream_name             = 'force1';             % optional
 %
-%--------------------------------------------------------------------------
+% 
+% 
+%
+%
 % Optional Inputs :
 %       Provide optional inputs as key value pairs.
 %       Usage:
@@ -90,6 +93,7 @@ function bemobil_xdf2bids(config, varargin)
 % Authors :
 %       Sein Jeung (seinjeung@gmail.com) & Soeren Grothkopp (s.grothkopp@secure.mailbox.org)
 %--------------------------------------------------------------------------
+
 
 % add load_xdf to path
 ft_defaults
@@ -162,14 +166,15 @@ if importMotion
     end
     
     % default channel types and units
+    % following CMIXF-12, BIDS v1.8.0 appendix on Units
     motion_type.POS.unit        = 'm';
     motion_type.ORNT.unit       = 'rad';
     motion_type.VEL.unit        = 'm/s';
-    motion_type.ANGVEL.unit     = 'r/s';
-    motion_type.ACC.unit        = 'm/s^2';
-    motion_type.ANGACC.unit     = 'r/s^2';
+    motion_type.GYRO.unit       = 'rad/s';
+    motion_type.ACCEL.unit      = 'm/s^2';
+    motion_type.ANGACC.unit     = 'rad/s^2';
     motion_type.MAGN.unit       = 'fm';
-    motion_type.JNTANG.unit     = 'r';
+    motion_type.JNTANG.unit     = 'rad';
     motion_type.LATENCY.unit    = 'seconds';
     
 end

--- a/import/bemobil_xdf2bids.m
+++ b/import/bemobil_xdf2bids.m
@@ -985,7 +985,11 @@ if importMotion
                 motioncfg.channels.placement{end+1}            = 'n/a';
             end
             
-            motioncfg.channels.component{end+1}    = splitlabel{end};
+            if strcmp(splitlabel{end-1}, 'quat')
+                motioncfg.channels.component{end+1}    = ['quat_' splitlabel{end}];
+            else
+                motioncfg.channels.component{end+1}    = splitlabel{end};
+            end
             
             % make sure that the type and component keywords conform to BIDS 
             if ~any(strcmp(motioncfg.channels.type{end},channelTypeKeywords))

--- a/pop/pop_importbids_mobi.m
+++ b/pop/pop_importbids_mobi.m
@@ -646,8 +646,8 @@ for iSubject = 2:size(bids.participants,1)
                 bids.otherdata  = [];
                 
                 % extract data type
-                splitName       = regexp(otherFileRaw,'_','split');
-                datatype        = splitName{end}(1:end-4);
+                splitName           = regexp(otherFileRaw,'_','split');
+                datatype            = splitName{end}(1:end-4);
              
                 joinedName          = join(splitName, '_'); 
                 otherFileJSON       = [joinedName{1}(1:end-3) 'json']; 
@@ -760,7 +760,7 @@ for iSubject = 2:size(bids.participants,1)
                                 useLatency = ~isempty(latencyInd);
                                 if useLatency
                                     latencyHeader   = channelData{latencyInd,strcmp(channelData(1,:),'name')};
-                                    latencyRowInData = find(strcmp(headers, latencyHeader));
+                                    latencyRowInData = latencyInd-1;
                                 end
                             elseif strcmp(datatype,'physio')
                                 % check if the tracking system comes with latency


### PR DESCRIPTION
Issue #77 was caused by latency values not being correctly read in. 
Since motion.tsv files have no headers but import script expects them, causing the time stamps to be reconstructed. 
Submitting other changes in metadata handling as well. 